### PR TITLE
feat: add HU CSV import settings page

### DIFF
--- a/public/hu_template.csv
+++ b/public/hu_template.csv
@@ -1,0 +1,3 @@
+length_cm,width_cm,height_cm,weight_kg,stackable,deliveryDate,place
+240,100,110,480,false,2025-09-20,Lyon
+120,80,75,220,true,2025-09-18,Lyon

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { NavLink, Route, Routes } from "react-router-dom";
 import OptiPlan from "./pages/OptiPlan";
 import OptiContainer from "./pages/OptiContainer";
+import Settings from "./pages/Settings";
 
 export default function App() {
   return (
@@ -9,10 +10,12 @@ export default function App() {
       <nav className="nav" style={{ padding: "1rem", display: "flex", gap: "1rem" }}>
         <NavLink to="/plan">OptiPlan</NavLink>
         <NavLink to="/container">OptiContainer</NavLink>
+        <NavLink to="/settings">Settings</NavLink>
       </nav>
       <Routes>
         <Route path="/plan" element={<OptiPlan />} />
         <Route path="/container" element={<OptiContainer />} />
+        <Route path="/settings" element={<Settings />} />
         <Route path="*" element={<OptiPlan />} />
       </Routes>
     </div>

--- a/src/HUsContext.tsx
+++ b/src/HUsContext.tsx
@@ -1,0 +1,42 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { HU } from "./types";
+
+type HUsContextValue = {
+  hus: HU[];
+  setHUs: React.Dispatch<React.SetStateAction<HU[]>>;
+};
+
+const HUsContext = createContext<HUsContextValue | undefined>(undefined);
+
+const SAMPLE_HUS: HU[] = [
+  { id: "HU-001", length_cm: 240, width_cm: 100, height_cm: 110, weight_kg: 480, stackable: false, deliveryDate: "2025-09-20", place: "Lyon" },
+  { id: "HU-002", length_cm: 120, width_cm: 80, height_cm: 75, weight_kg: 220, stackable: true, deliveryDate: "2025-09-18", place: "Lyon" },
+  { id: "HU-003", length_cm: 310, width_cm: 90, height_cm: 100, weight_kg: 600, stackable: true, deliveryDate: "2025-09-25", place: "Bordeaux" },
+  { id: "HU-004", length_cm: 200, width_cm: 120, height_cm: 150, weight_kg: 350, stackable: true, deliveryDate: "2025-09-18", place: "Lyon" },
+];
+
+export function HUsProvider({ children }: { children: React.ReactNode }) {
+  const [hus, setHUs] = useState<HU[]>(() => {
+    const stored = localStorage.getItem("hus");
+    if (stored) {
+      try {
+        return JSON.parse(stored) as HU[];
+      } catch {
+        /* ignore */
+      }
+    }
+    return SAMPLE_HUS;
+  });
+
+  useEffect(() => {
+    localStorage.setItem("hus", JSON.stringify(hus));
+  }, [hus]);
+
+  return <HUsContext.Provider value={{ hus, setHUs }}>{children}</HUsContext.Provider>;
+}
+
+export function useHUs() {
+  const ctx = useContext(HUsContext);
+  if (!ctx) throw new Error("useHUs must be used within HUsProvider");
+  return ctx;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./styles.css";
+import { HUsProvider } from "./HUsContext";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <HUsProvider>
+        <App />
+      </HUsProvider>
     </BrowserRouter>
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/src/pages/OptiContainer.tsx
+++ b/src/pages/OptiContainer.tsx
@@ -6,16 +6,12 @@ import { HUList } from "../components/HUList";
 import { Legend } from "../components/Legend";
 import { Viewer3D } from "../components/Viewer3D";
 import { StatsBar } from "../components/StatsBar";
+import { useHUs } from "../HUsContext";
 
 export default function OptiContainer(){
   const [containerType, setContainerType] = useState<ContainerTypeKey>("20GP");
   const dims = CONTAINERS[containerType];
-  const [hus, setHUs] = useState<HU[]>([
-    { id: "HU-001", length_cm: 240, width_cm: 100, height_cm: 110, weight_kg: 480, stackable: false, deliveryDate: "2025-09-20", place: "Lyon" },
-    { id: "HU-002", length_cm: 120, width_cm: 80, height_cm: 75, weight_kg: 220, stackable: true, deliveryDate: "2025-09-18", place: "Lyon" },
-    { id: "HU-003", length_cm: 310, width_cm: 90, height_cm: 100, weight_kg: 600, stackable: true, deliveryDate: "2025-09-25", place: "Bordeaux" },
-    { id: "HU-004", length_cm: 200, width_cm: 120, height_cm: 150, weight_kg: 350, stackable: true, deliveryDate: "2025-09-18", place: "Lyon" },
-  ]);
+  const { hus, setHUs } = useHUs();
   const [selectedHUId, setSelectedHUId] = useState<string|null>(null);
   const [currentContainerIdx, setCurrentContainerIdx] = useState(0);
   const [repackVersion, setRepackVersion] = useState(0);

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+import { HU } from "../types";
+import { useHUs } from "../HUsContext";
+
+export default function Settings() {
+  const { hus, setHUs } = useHUs();
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const text = await file.text();
+      const lines = text.trim().split(/\r?\n/);
+      const [header, ...rows] = lines;
+      const cols = header.split(",").map((c) => c.trim());
+      const imported: HU[] = rows.filter(r=>r.trim().length>0).map((line) => {
+        const parts = line.split(",");
+        const obj: Record<string, string> = {};
+        cols.forEach((c, i) => {
+          obj[c] = parts[i]?.trim() || "";
+        });
+        const id = `HU-${crypto.randomUUID().slice(0, 8).toUpperCase()}`;
+        return {
+          id,
+          length_cm: Number(obj.length_cm) || 0,
+          width_cm: Number(obj.width_cm) || 0,
+          height_cm: Number(obj.height_cm) || 0,
+          weight_kg: Number(obj.weight_kg) || 0,
+          stackable: /^true|1|yes$/i.test(obj.stackable),
+          deliveryDate: obj.deliveryDate || new Date().toISOString().slice(0, 10),
+          place: obj.place || "",
+        } as HU;
+      });
+      setHUs((prev) => [...prev, ...imported]);
+      setError(null);
+    } catch (err) {
+      setError("Failed to parse CSV");
+    }
+    e.target.value = "";
+  };
+
+  const removeHU = (id: string) => setHUs((p) => p.filter((h) => h.id !== id));
+
+  return (
+    <div className="layout">
+      <h1>Settings</h1>
+      <div className="card">
+        <div className="card-title">Import Handling Units from CSV</div>
+        <div className="muted">
+          CSV columns: length_cm,width_cm,height_cm,weight_kg,stackable,deliveryDate,place. <a href="/hu_template.csv" download>Download template</a>
+        </div>
+        <input type="file" accept=".csv" onChange={handleFile} />
+        {error && <div className="error">{error}</div>}
+      </div>
+
+      <div className="card">
+        <div className="card-title">Loaded Handling Units</div>
+        <div className="list">
+          {hus.map((h) => (
+            <div key={h.id} className="list-item">
+              <div>
+                <div className="list-title">{h.id}</div>
+                <div className="muted">{h.length_cm}×{h.width_cm}×{h.height_cm} cm · {h.weight_kg} kg · {h.stackable ? "Stackable" : "No stack"}</div>
+                <div className="muted">{h.deliveryDate} — {h.place}</div>
+              </div>
+              <div className="row gap">
+                <button className="btn danger" onClick={() => removeHU(h.id)}>Remove</button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add global HUs context persisted to localStorage
- create Settings page with CSV import and template download
- wire Settings page and shared state into app navigation

## Testing
- `npm run build` *(fails: Cannot find module 'react-router-dom')*


------
https://chatgpt.com/codex/tasks/task_e_68ba84f9def0832c9b33960539d265f5