### PR TITLE
Use modal for HU editing

### DIFF
--- a/src/components/HUEditModal.tsx
+++ b/src/components/HUEditModal.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from "react";
+import { HU } from "../types";
+
+export function HUEditModal({ hu, onSave, onCancel }: { hu: HU; onSave: (hu: HU) => void; onCancel: () => void }) {
+  const [form, setForm] = useState({
+    length_cm: String(hu.length_cm),
+    width_cm: String(hu.width_cm),
+    height_cm: String(hu.height_cm),
+    weight_kg: String(hu.weight_kg),
+    stackable: hu.stackable,
+    deliveryDate: hu.deliveryDate,
+    place: hu.place,
+  });
+
+  const parse = (s: string, fallback: number) => {
+    const n = Number(s);
+    return isNaN(n) ? fallback : n;
+  };
+
+  const save = () => {
+    const updated: HU = {
+      ...hu,
+      length_cm: parse(form.length_cm, hu.length_cm),
+      width_cm: parse(form.width_cm, hu.width_cm),
+      height_cm: parse(form.height_cm, hu.height_cm),
+      weight_kg: parse(form.weight_kg, hu.weight_kg),
+      stackable: form.stackable,
+      deliveryDate: form.deliveryDate,
+      place: form.place,
+    };
+    onSave(updated);
+  };
+
+  return (
+    <div className="modal-overlay">
+      <div className="card modal">
+        <div className="card-title">Edit {hu.id}</div>
+        <div className="grid2">
+          <div><label className="label">Length (cm)</label><input className="input" value={form.length_cm} onChange={(e)=>setForm({...form,length_cm:e.target.value})} /></div>
+          <div><label className="label">Width (cm)</label><input className="input" value={form.width_cm} onChange={(e)=>setForm({...form,width_cm:e.target.value})} /></div>
+          <div><label className="label">Height (cm)</label><input className="input" value={form.height_cm} onChange={(e)=>setForm({...form,height_cm:e.target.value})} /></div>
+          <div><label className="label">Weight (kg)</label><input className="input" value={form.weight_kg} onChange={(e)=>setForm({...form,weight_kg:e.target.value})} /></div>
+          <div className="row"><label className="label">Stackable</label><button className={`toggle ${form.stackable?"on":""}`} onClick={()=>setForm({...form,stackable:!form.stackable})}>{form.stackable?"Yes":"No"}</button></div>
+          <div><label className="label">Delivery date</label><input type="date" className="input" value={form.deliveryDate} onChange={(e)=>setForm({...form,deliveryDate:e.target.value})} /></div>
+          <div className="col2"><label className="label">Place of delivery</label><input className="input" value={form.place} onChange={(e)=>setForm({...form,place:e.target.value})} /></div>
+        </div>
+        <div className="row gap">
+          <button className="btn primary" onClick={save}>Save</button>
+          <button className="btn" onClick={onCancel}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/OptiContainer.tsx
+++ b/src/pages/OptiContainer.tsx
@@ -6,6 +6,7 @@ import { HUList } from "../components/HUList";
 import { Legend } from "../components/Legend";
 import { Viewer3D } from "../components/Viewer3D";
 import { StatsBar } from "../components/StatsBar";
+import { HUEditModal } from "../components/HUEditModal";
 import { useHUs } from "../HUsContext";
 
 export default function OptiContainer(){
@@ -24,44 +25,18 @@ export default function OptiContainer(){
   const stops = useMemo(()=>{ const s = new Set<string>(); for (const p of plan?.placements || []) s.add(p.stopKey); return Array.from(s); }, [plan]);
 
   const removeHU = (id: string) => { setHUs((prev)=>prev.filter((x)=>x.id!==id)); if (selectedHUId===id) setSelectedHUId(null); };
-
-  const editHU = (hu: HU) => {
-    const parse = (s: string | null, fallback: number) => {
-      if (s === null) return fallback;
-      const n = Number(s);
-      return isNaN(n) ? fallback : n;
-    };
-    const lengthStr = prompt("Length (cm)", String(hu.length_cm));
-    if (lengthStr === null) return;
-    const widthStr = prompt("Width (cm)", String(hu.width_cm));
-    if (widthStr === null) return;
-    const heightStr = prompt("Height (cm)", String(hu.height_cm));
-    if (heightStr === null) return;
-    const weightStr = prompt("Weight (kg)", String(hu.weight_kg));
-    if (weightStr === null) return;
-    const stackableStr = prompt("Stackable? (yes/no)", hu.stackable ? "yes" : "no");
-    if (stackableStr === null) return;
-    const deliveryDateStr = prompt("Delivery date (YYYY-MM-DD)", hu.deliveryDate);
-    if (deliveryDateStr === null) return;
-    const placeStr = prompt("Place of delivery", hu.place);
-    if (placeStr === null) return;
-    const updated: HU = {
-      ...hu,
-      length_cm: parse(lengthStr, hu.length_cm),
-      width_cm: parse(widthStr, hu.width_cm),
-      height_cm: parse(heightStr, hu.height_cm),
-      weight_kg: parse(weightStr, hu.weight_kg),
-      stackable: stackableStr.trim().toLowerCase().startsWith("y"),
-      deliveryDate: deliveryDateStr,
-      place: placeStr,
-    };
-    setHUs((prev) => prev.map((x) => (x.id === hu.id ? updated : x)));
+  const [editingHU, setEditingHU] = useState<HU|null>(null);
+  const editHU = (hu: HU) => { setEditingHU(hu); };
+  const handleSaveHU = (hu: HU) => {
+    setHUs((prev) => prev.map((x) => (x.id === hu.id ? hu : x)));
     setCurrentContainerIdx(0);
+    setEditingHU(null);
   };
 
   return (
-    <div className="layout">
-      <header className="header">
+    <>
+      <div className="layout">
+        <header className="header">
         <h1>Container Optimizer — MVP</h1>
         <div className="segmented">
           <button className={`seg ${containerType==="20GP"?"active":""}`} onClick={()=>{ setContainerType("20GP"); setCurrentContainerIdx(0); }}>20′ Standard</button>
@@ -126,5 +101,7 @@ export default function OptiContainer(){
 
       <footer className="footer">MVP heuristic — add door aperture checks, center-of-gravity and stackability rules before production.</footer>
     </div>
+      {editingHU && <HUEditModal hu={editingHU} onSave={handleSaveHU} onCancel={()=>setEditingHU(null)} />}
+    </>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -56,3 +56,5 @@ body{margin:0; font-family: ui-sans-serif, system-ui, Segoe UI, Roboto, Helvetic
 .table tr.active td{outline:1px solid #3b82f6}
 .footer{color:var(--muted); font-size:12px; text-align:center; margin-top:8px}
 @media (max-width: 980px){ .content{grid-template-columns: 1fr} }
+.modal-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:1000}
+.modal{max-width:400px;width:100%}


### PR DESCRIPTION
## Summary
- Replace browser prompts with a state-driven modal for editing Handling Units
- Add `HUEditModal` component and corresponding styles

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba8e587640832cbb5f16e593586b29