### PR TITLE
Enable rotation and free 3D movement for handling units

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -45,8 +45,10 @@ body{margin:0; font-family: ui-sans-serif, system-ui, Segoe UI, Roboto, Helvetic
 .legend-item{display:flex; align-items:center; gap:6px; font-size:12px; color:#dbe3ef}
 .legend-dot{width:10px; height:10px; border-radius:50%}
 .toolbar{display:flex; align-items:center; justify-content:space-between}
-.viewer{height:520px; border:1px solid var(--border); border-radius:16px; background:#0d1428; overflow:hidden; box-shadow:var(--shadow)}
+.viewer{height:520px; border:1px solid var(--border); border-radius:16px; background:#0d1428; overflow:hidden; box-shadow:var(--shadow); position:relative}
 .door-label{background:#0b1225; color:#fff; padding:4px 6px; font-size:10px; border:1px solid #203159; border-radius:6px}
+.error{color:var(--danger); margin-top:8px}
+.viewer-error{position:absolute; top:8px; left:8px; background:rgba(0,0,0,0.6); padding:4px 8px; border-radius:6px}
 .table-wrap{max-height:240px; overflow:auto}
 .table{width:100%; border-collapse:separate; border-spacing:0 6px}
 .table th{font-size:12px; color:var(--muted); text-align:left; padding:6px 8px}


### PR DESCRIPTION
## Summary
- Allow HU rotation on double-click inside 3D viewer
- Enable HU drag along any axis and flag out-of-bounds placements
- Add styles for error overlays and container-relative positioning

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba9bd5164c832c92167c59451a6986