### PR TITLE
Clear persisted container assignments on startup

### DIFF
--- a/src/ContainersContext.tsx
+++ b/src/ContainersContext.tsx
@@ -13,7 +13,9 @@ export function ContainersProvider({ children }: { children: React.ReactNode }) 
     const stored = localStorage.getItem("containers");
     if (stored) {
       try {
-        return JSON.parse(stored) as ManagedContainer[];
+        // Drop any persisted HU assignments so containers start empty
+        const parsed = JSON.parse(stored) as ManagedContainer[];
+        return parsed.map(c => ({ ...c, huIds: [] }));
       } catch {
         /* ignore */
       }


### PR DESCRIPTION
## Summary
- Strip HU assignments from stored containers so sessions start with no container allocations

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bad315bc4c832ca309ba84ec6452d3