### PR TITLE
feat: expose auto allocation rules

### DIFF
--- a/src/AutoAllocateRulesContext.tsx
+++ b/src/AutoAllocateRulesContext.tsx
@@ -1,0 +1,49 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+export type AutoAllocateRules = {
+  lifoByDelivery: boolean;
+  respectStackable: boolean;
+};
+
+type AutoAllocateRulesContextValue = {
+  rules: AutoAllocateRules;
+  setRules: React.Dispatch<React.SetStateAction<AutoAllocateRules>>;
+};
+
+const defaultRules: AutoAllocateRules = {
+  lifoByDelivery: true,
+  respectStackable: true,
+};
+
+const AutoAllocateRulesContext = createContext<AutoAllocateRulesContextValue | undefined>(undefined);
+
+export function AutoAllocateRulesProvider({ children }: { children: React.ReactNode }) {
+  const [rules, setRules] = useState<AutoAllocateRules>(() => {
+    const stored = localStorage.getItem("autoAllocateRules");
+    if (stored) {
+      try {
+        return { ...defaultRules, ...JSON.parse(stored) } as AutoAllocateRules;
+      } catch {
+        /* ignore */
+      }
+    }
+    return defaultRules;
+  });
+
+  useEffect(() => {
+    localStorage.setItem("autoAllocateRules", JSON.stringify(rules));
+  }, [rules]);
+
+  return (
+    <AutoAllocateRulesContext.Provider value={{ rules, setRules }}>
+      {children}
+    </AutoAllocateRulesContext.Provider>
+  );
+}
+
+export function useAutoAllocateRules() {
+  const ctx = useContext(AutoAllocateRulesContext);
+  if (!ctx) throw new Error("useAutoAllocateRules must be used within AutoAllocateRulesProvider");
+  return ctx;
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,13 +5,16 @@ import App from "./App";
 import "./styles.css";
 import { HUsProvider } from "./HUsContext";
 import { ContainersProvider } from "./ContainersContext";
+import { AutoAllocateRulesProvider } from "./AutoAllocateRulesContext";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <BrowserRouter>
       <ContainersProvider>
         <HUsProvider>
-          <App />
+          <AutoAllocateRulesProvider>
+            <App />
+          </AutoAllocateRulesProvider>
         </HUsProvider>
       </ContainersProvider>
     </BrowserRouter>

--- a/src/pages/OptiContainer.tsx
+++ b/src/pages/OptiContainer.tsx
@@ -9,6 +9,7 @@ import { StatsBar } from "../components/StatsBar";
 import { HUEditModal } from "../components/HUEditModal";
 import { useHUs } from "../HUsContext";
 import { useContainers } from "../ContainersContext";
+import { useAutoAllocateRules } from "../AutoAllocateRulesContext";
 
 export default function OptiContainer(){
   const [containerType, setContainerType] = useState<ContainerTypeKey>("20GP");
@@ -17,6 +18,7 @@ export default function OptiContainer(){
   const [selectedHUId, setSelectedHUId] = useState<string|null>(null);
   const [currentContainerIdx, setCurrentContainerIdx] = useState<number>(-1);
   const [placementsMap, setPlacementsMap] = useState<Record<number, Placement[]>>({});
+  const { rules } = useAutoAllocateRules();
 
   const currentContainer = containers[currentContainerIdx];
   const placements = placementsMap[currentContainerIdx] || [];
@@ -66,7 +68,7 @@ export default function OptiContainer(){
   };
 
   const autoAllocate = () => {
-    const plans = packHUsIntoContainers(hus, containerType);
+    const plans = packHUsIntoContainers(hus, containerType, rules);
     const managed: ManagedContainer[] = plans.map((p,i)=>({ id:`C-${i+1}`, type:p.type, properties:p.dims, huIds:p.placements.map(pl=>pl.huId) }));
     const map: Record<number, Placement[]> = {};
     plans.forEach((p,i)=>{ map[i]=p.placements; });

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from "react";
 import { HU } from "../types";
 import { useHUs } from "../HUsContext";
+import { useAutoAllocateRules } from "../AutoAllocateRulesContext";
 
 export default function Settings() {
   const { hus, setHUs } = useHUs();
+  const { rules, setRules } = useAutoAllocateRules();
   const [error, setError] = useState<string | null>(null);
 
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -55,11 +57,11 @@ export default function Settings() {
       </div>
 
       <div className="card">
-        <div className="card-title">Loaded Handling Units</div>
-        <div className="list">
-          {hus.map((h) => (
-            <div key={h.id} className="list-item">
-              <div>
+      <div className="card-title">Loaded Handling Units</div>
+      <div className="list">
+        {hus.map((h) => (
+          <div key={h.id} className="list-item">
+            <div>
                 <div className="list-title">{h.id}</div>
                 <div className="muted">{h.length_cm}×{h.width_cm}×{h.height_cm} cm · {h.weight_kg} kg · {h.stackable ? "Stackable" : "No stack"}</div>
                 <div className="muted">{h.deliveryDate} — {h.place}</div>
@@ -68,9 +70,31 @@ export default function Settings() {
                 <button className="btn danger" onClick={() => removeHU(h.id)}>Remove</button>
               </div>
             </div>
-          ))}
-        </div>
+        ))}
       </div>
     </div>
+
+    <div className="card">
+      <div className="card-title">Auto allocation rules</div>
+      <div className="list">
+        <label className="row gap">
+          <input
+            type="checkbox"
+            checked={rules.lifoByDelivery}
+            onChange={(e) => setRules(r => ({ ...r, lifoByDelivery: e.target.checked }))}
+          />
+          <span>LIFO by delivery (latest stop at far end)</span>
+        </label>
+        <label className="row gap">
+          <input
+            type="checkbox"
+            checked={rules.respectStackable}
+            onChange={(e) => setRules(r => ({ ...r, respectStackable: e.target.checked }))}
+          />
+          <span>Prevent stacking above non-stackable HUs</span>
+        </label>
+      </div>
+    </div>
+  </div>
   );
 }


### PR DESCRIPTION
## Summary
- store auto allocation rules in new context persisted to local storage
- allow toggling LIFO and stacking rules from settings
- apply selected rules when auto allocating handling units

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bad5409868832cae19146fd1867201